### PR TITLE
Bug fix when setting title for downloaded threads in some instances

### DIFF
--- a/4ChanArchiveAssistant.py
+++ b/4ChanArchiveAssistant.py
@@ -29,7 +29,7 @@ def download_from_thread(thread_url):
         print("Thread not found!")
         return
 
-    title = thread.topic.subject if thread.topic.subject else ' '.join(thread.topic.text.split()[:5])
+    title = thread.topic.subject if thread.topic.subject else ' '.join(thread.topic.text.split()[:5]) if hasattr(thread.topic, "text") else thread_id
     folder_name = title.replace('/', '_').replace('\\', '_').replace(':', '_').replace('*', '_').replace('?', '_').replace('"', '_').replace('<', '_').replace('>', '_').replace('|', '_')
     full_save_path = os.path.join(SAVE_DIRECTORY, folder_name)
 


### PR DESCRIPTION
## What?
When setting the title variable, handles the edge case in some threads where the topic post has no text field.
## Why?
Encountered an issue with a certain thread in /wg/, which had no text attribute for some reason.
## How?
When title variable is set, if there is no thread topic, it also checks if the thread topic has a text field before setting the variable to that text.
## Testing?
Tested with that same thread, works fine now.